### PR TITLE
feat: docker authentication plugin

### DIFF
--- a/hubble/api.py
+++ b/hubble/api.py
@@ -12,10 +12,7 @@ def logout(*args):
 
 def login(args):
     client = Client(jsonify=True)
-
-    from rich.console import Console
-
-    console = Console()
+    nickname = ''
 
     if args.force:
         _login(prompt='login', force=True)
@@ -23,7 +20,20 @@ def login(args):
 
     try:
         nickname = client.username
+    except Exception as ex:
+        if isinstance(ex, (AuthenticationRequiredError, AuthenticationFailedError)):
+            _login(prompt='login')
+        else:
+            raise ex
+    else:
+        from .dockerauth import auto_deploy_hubble_docker_credential_helper
+
+        auto_deploy_hubble_docker_credential_helper()
+
         if nickname:
+            from rich.console import Console
+
+            console = Console()
             console.print(
                 f':closed_lock_with_key: You are already logged in as [b green]{nickname}[/b green].',
                 '',
@@ -32,11 +42,6 @@ def login(args):
                 '- or, [b]jina auth login -f[/]',
                 sep=os.linesep,
             )
-    except Exception as ex:
-        if isinstance(ex, (AuthenticationRequiredError, AuthenticationFailedError)):
-            _login(prompt='login')
-        else:
-            raise ex
 
 
 def token(args):

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -260,3 +260,15 @@ class Client(BaseClient):
             url=self._base_url + EndpointsV2.list_artifacts,
             json={key: value for (key, value) in data.items() if value is not None},
         )
+
+    def list_internal_docker_registries(
+        self,
+    ) -> Union[requests.Response, dict]:
+        """List internal docker registries.
+
+        :returns: `requests.Response` object as returned value
+            or indented json if jsonify.
+        """
+        return self.handle_request(
+            url=self._base_url + EndpointsV2.list_internal_docker_registries,
+        )

--- a/hubble/client/endpoints.py
+++ b/hubble/client/endpoints.py
@@ -5,12 +5,20 @@ from dataclasses import dataclass
 class EndpointsV2(object):
     """All available Hubble API endpoints."""
 
+    initiate_session_authorize: str = 'user.identity.authorize'
+    initiate_proxied_authorize: str = 'user.identity.proxiedAuthorize'
+    auto_grant_user_identity: str = 'user.identity.grant.auto'
+    get_user_info: str = 'user.identity.whoami'
+    dismiss_user_session: str = 'user.session.dismiss'
+
     create_pat: str = 'user.pat.create'
     list_pats: str = 'user.pat.list'
     delete_pat: str = 'user.pat.delete'
-    get_user_info: str = 'user.identity.whoami'
+
     upload_artifact: str = 'artifact.upload'
     download_artifact: str = 'artifact.getDownloadUrl'
     delete_artifact: str = 'artifact.delete'
     get_artifact_info: str = 'artifact.getDetail'
     list_artifacts: str = 'artifact.list'
+
+    list_internal_docker_registries: str = 'dockerRegistry.listInternalRegistries'

--- a/hubble/dockerauth.py
+++ b/hubble/dockerauth.py
@@ -28,17 +28,20 @@ def get_credentials_for(_registry: str):
     """
     c = Client(jsonify=True).token
     token = os.environ.get('JINA_AUTH_TOKEN', c)
-    print(json.dumps({'Username': '<token>', 'Secret': token if token else 'anonymous'}, indent=4))
+    username = os.environ.get('HUBBLE_DOCKER_AUTH_OVERRIDE_USERNAME', '<token>')
+    secret = os.environ.get('HUBBLE_DOCKER_AUTH_OVERRIDE_SECRET', token)
 
+    sys.stdout.write(json.dumps({'Username': username, 'Secret': secret if secret else 'anonymous'}, indent=4))
+    sys.stdout.write('\n');
 
 def main():
     """
     Main entry point.
     """
     import argparse
-    parser = argparse.ArgumentParser(description='Deploy hubble docker credential helper for the registry.')
+    parser = argparse.ArgumentParser(description='Hubble docker credential helper for the registry.')
     parser.add_argument('action', nargs='?', default='get', help='Action: get, store, erase, or deploy')
-    parser.add_argument('--registry', nargs='?', help='The registry to deploy the helper for.')
+    parser.add_argument('registry', nargs='?', help='The registry to deploy helper for.')
 
     args = parser.parse_args()
 

--- a/hubble/dockerauth.py
+++ b/hubble/dockerauth.py
@@ -28,7 +28,7 @@ def get_credentials_for(_registry: str):
     """
     c = Client(jsonify=True).token
     token = os.environ.get('JINA_AUTH_TOKEN', c)
-    print(json.dumps({'Username': '<token>', 'Password': token if token else ''}, indent=4))
+    print(json.dumps({'Username': '<token>', 'Secret': token if token else 'anonymous'}, indent=4))
 
 
 def main():

--- a/hubble/dockerauth.py
+++ b/hubble/dockerauth.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
+import json
 import os
 import sys
-import json
-
 from pathlib import Path
+
 from .client.client import Client  # noqa F401
+
 
 def deploy_hubble_docker_credential_helper_for(registry: str):
     """
@@ -15,7 +16,7 @@ def deploy_hubble_docker_credential_helper_for(registry: str):
     if docker_config_file_path.exists():
         with docker_config_file_path.open('r+') as f:
             target_conf = json.load(f)
-    if ('credHelpers' not in target_conf):
+    if 'credHelpers' not in target_conf:
         target_conf['credHelpers'] = {}
     target_conf['credHelpers'][registry] = 'jina-hubble'
     with docker_config_file_path.open('w') as f:
@@ -31,17 +32,30 @@ def get_credentials_for(_registry: str):
     username = os.environ.get('HUBBLE_DOCKER_AUTH_OVERRIDE_USERNAME', '<token>')
     secret = os.environ.get('HUBBLE_DOCKER_AUTH_OVERRIDE_SECRET', token)
 
-    sys.stdout.write(json.dumps({'Username': username, 'Secret': secret if secret else 'anonymous'}, indent=4))
-    sys.stdout.write('\n');
+    sys.stdout.write(
+        json.dumps(
+            {'Username': username, 'Secret': secret if secret else 'anonymous'},
+            indent=4,
+        )
+    )
+    sys.stdout.write('\n')
+
 
 def main():
     """
     Main entry point.
     """
     import argparse
-    parser = argparse.ArgumentParser(description='Hubble docker credential helper for the registry.')
-    parser.add_argument('action', nargs='?', default='get', help='Action: get, store, erase, or deploy')
-    parser.add_argument('registry', nargs='?', help='The registry to deploy helper for.')
+
+    parser = argparse.ArgumentParser(
+        description='Hubble docker credential helper for the registry.'
+    )
+    parser.add_argument(
+        'action', nargs='?', default='get', help='Action: get, store, erase, or deploy'
+    )
+    parser.add_argument(
+        'registry', nargs='?', help='The registry to deploy helper for.'
+    )
 
     args = parser.parse_args()
 

--- a/hubble/dockerauth.py
+++ b/hubble/dockerauth.py
@@ -80,7 +80,7 @@ def main():
         if not args.registry:
             auto_deploy_hubble_docker_credential_helper()
             sys.exit(1)
-        deploy_hubble_docker_credential_helper_for(*args.registry)
+        deploy_hubble_docker_credential_helper_for(args.registry)
         sys.exit(0)
     else:
         sys.exit(1)

--- a/hubble/dockerauth.py
+++ b/hubble/dockerauth.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+import os
+import sys
+import json
+
+from pathlib import Path
+from .client.client import Client  # noqa F401
+
+def deploy_hubble_docker_credential_helper_for(registry: str):
+    """
+    Deploy hubble docker credential helper for the registry.
+    """
+    docker_config_file_path = Path(os.path.expanduser('~/.docker/config.json'))
+    target_conf = {}
+    if docker_config_file_path.exists():
+        with docker_config_file_path.open('r+') as f:
+            target_conf = json.load(f)
+    if ('credHelpers' not in target_conf):
+        target_conf['credHelpers'] = {}
+    target_conf['credHelpers'][registry] = 'jina-hubble'
+    with docker_config_file_path.open('w') as f:
+        json.dump(target_conf, f, sort_keys=True, indent=8)
+
+
+def get_credentials_for(_registry: str):
+    """
+    Get credentials for the registry.
+    """
+    c = Client(jsonify=True).token
+    token = os.environ.get('JINA_AUTH_TOKEN', c)
+    print(json.dumps({'Username': '<token>', 'Password': token if token else ''}, indent=4))
+
+
+def main():
+    """
+    Main entry point.
+    """
+    import argparse
+    parser = argparse.ArgumentParser(description='Deploy hubble docker credential helper for the registry.')
+    parser.add_argument('action', nargs='?', default='get', help='Action: get, store, erase, or deploy')
+    parser.add_argument('--registry', nargs='?', help='The registry to deploy the helper for.')
+
+    args = parser.parse_args()
+
+    # sys.stdin.readlines()
+
+    if args.action == 'get':
+        get_credentials_for(args.registry)
+        sys.exit(0)
+    elif args.action == 'deploy':
+        if not args.registry:
+            print('Please specify the registry to deploy the helper for.')
+            sys.exit(1)
+        deploy_hubble_docker_credential_helper_for(args.registry)
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -102,6 +102,13 @@ class Auth:
                 user = json_response['data']['user']['nickname']
 
                 config.set('auth_token', token)
+
+                from hubble.dockerauth import (
+                    auto_deploy_hubble_docker_credential_helper,
+                )
+
+                auto_deploy_hubble_docker_credential_helper()
+
                 print(
                     f':closed_lock_with_key: [green]Successfully logged in to Jina AI[/] as [b]{user}[/b]!'
                 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-version = 0.11.0
+version = 0.12.0
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ if __name__ == '__main__':
         entry_points={
             'console_scripts': [
                 'jina-auth=hubble.__main__:main',
+                'docker-authentication-jina-hubble=hubble.dockerauth:main',
             ],
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         entry_points={
             'console_scripts': [
                 'jina-auth=hubble.__main__:main',
-                'docker-authentication-jina-hubble=hubble.dockerauth:main',
+                'docker-credential-jina-hubble=hubble.dockerauth:main',
             ],
         },
     )

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -109,3 +109,18 @@ def test_upload_download_artifact_bytes(client):
 
     resp = client.delete_artifact(id=artifact_id1)
     assert_response(resp)
+
+
+@pytest.mark.parametrize(
+    'client', [{'jsonify': True}, {'jsonify': False}], indirect=True
+)
+def test_list_internal_docker_registries(client):
+    resp = client.list_internal_docker_registries()
+    assert_response(resp)
+
+    if not client._jsonify:
+        resp = resp.json()
+
+    registries = resp['data']
+
+    assert type(registries[0]) is str


### PR DESCRIPTION
This deploys `docker credentials helper` for hubble internal registries when the user logs in.

For the big picture you can refer to https://github.com/jina-ai/hubble/blob/master/docs/docker-authentication-layer.md

This is for the jina client to properly pull from hubble internal private docker registries.

It loads the hubble auth token and sends this token into docker daemon context, which will eventually requests an access token from hubble API server with the auth token.

For the concept of docker credentials helper, please refer to https://docs.docker.com/engine/reference/commandline/login/#credential-helpers

