### PR TITLE
fix: extend login to expired tokens

### DIFF
--- a/hubble/__init__.py
+++ b/hubble/__init__.py
@@ -9,7 +9,7 @@ from typing import Optional
 from importlib_metadata import PackageNotFoundError, version
 
 from .client.client import Client  # noqa F401
-from .excepts import AuthenticationRequiredError
+from .excepts import AuthenticationFailedError, AuthenticationRequiredError
 from .utils.auth import Auth  # noqa F401
 
 try:
@@ -39,7 +39,15 @@ def login_required(func):
     @wraps(func)
     def arg_wrapper(*args, **kwargs):
         if Client(jsonify=True).token:
-            return func(*args, **kwargs)
+            try:
+                Client(jsonify=True).get_user_info()
+                return func(*args, **kwargs)
+            except AuthenticationRequiredError:
+                raise AuthenticationFailedError(
+                    response={},
+                    message=f'Jina auth token has expired. {func!r} requires login to Jina AI, '
+                    f'please do `jina auth login -f` or set env variable `JINA_AUTH_TOKEN` with updated token',
+                ) from None
         else:
             raise AuthenticationRequiredError(
                 response={},

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ isort==5.10.1
 pytest==7.0.0
 pytest-cov==3.0.0
 pytest-mock==3.7.0
+mock==4.0.3

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -1,9 +1,10 @@
 import os
-from unittest.mock import patch
 
+import hubble
 import pytest
 from hubble import Client, login_required
-from hubble.excepts import AuthenticationRequiredError
+from hubble.excepts import AuthenticationFailedError, AuthenticationRequiredError
+from mock import patch
 
 
 @patch.dict(os.environ, {'JINA_AUTH_TOKEN': ''})
@@ -17,7 +18,7 @@ def test_handle_error_request(mocker, params):
 
 
 @patch.dict(os.environ, {'JINA_AUTH_TOKEN': ''})
-def test_auth_required_decorator_fail():
+def test_auth_required_decorator_no_token():
     @login_required
     def foo():
         print('hello!!!')
@@ -28,8 +29,20 @@ def test_auth_required_decorator_fail():
 
 @patch.dict(os.environ, {'JINA_AUTH_TOKEN': 'abc'})
 def test_auth_required_decorator_success():
-    @login_required
+    patch('hubble.login_required', lambda x: x).start()
+
+    @hubble.login_required
     def foo():
         print('hello!!!')
 
     foo()
+
+
+@patch.dict(os.environ, {'JINA_AUTH_TOKEN': 'somerandomtoken'})
+def test_auth_required_decorator_wrong_or_expired_token():
+    @login_required
+    def foo():
+        print('hello!!!')
+
+    with pytest.raises(AuthenticationFailedError):
+        foo()

--- a/tests/unit/client/test_client.py
+++ b/tests/unit/client/test_client.py
@@ -3,7 +3,7 @@ import os
 import hubble
 import pytest
 from hubble import Client, login_required
-from hubble.excepts import AuthenticationFailedError, AuthenticationRequiredError
+from hubble.excepts import AuthenticationRequiredError
 from mock import patch
 
 
@@ -44,5 +44,5 @@ def test_auth_required_decorator_wrong_or_expired_token():
     def foo():
         print('hello!!!')
 
-    with pytest.raises(AuthenticationFailedError):
+    with pytest.raises(AuthenticationRequiredError):
         foo()


### PR DESCRIPTION
Extend the `login_required` decorator to also check if the token is valid or expired and display the correct message.