### PR TITLE
fix: local logout should not dismiss token session

### DIFF
--- a/tests/unit/utils/test_auth.py
+++ b/tests/unit/utils/test_auth.py
@@ -89,7 +89,7 @@ class ValidateResponse:
         [None, 'SOME_TOKEN', 200, False],
     ],
 )
-async def test_login(
+async def test_login_logout(
     mocker, monkeypatch, existing_token, expected_token, validate_status_code, force
 ):
     def _mock_get_aiohttp(*args, **kwargs):
@@ -121,8 +121,10 @@ async def test_login(
     authorized_token = config.get('auth_token')
     assert authorized_token == expected_token
 
-    # removing token created by this test
-    config.delete('auth_token')
+    await Auth.logout()
+
+    token_after_logout = config.get('auth_token')
+    assert token_after_logout is None
 
     # putting back config token
     if config_token:

--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -41,3 +41,15 @@ def test_get_auth_token(config):
     os.environ['JINA_AUTH_TOKEN'] = 'my-token-from-env'
     assert config.get('auth_token') == 'my-token'
     assert auth.Auth.get_auth_token() == 'my-token-from-env'
+
+
+@patch.dict(os.environ, {'JINA_AUTH_TOKEN': ''})
+def test_get_auth_token_from_config(config):
+    auth.config = config
+    config.set('auth_token', 'my-token')
+    assert config.get('auth_token') == 'my-token'
+    assert auth.Auth.get_auth_token_from_config() == 'my-token'
+
+    os.environ['JINA_AUTH_TOKEN'] = 'my-token-from-env'
+    assert config.get('auth_token') == 'my-token'
+    assert auth.Auth.get_auth_token_from_config() == 'my-token'


### PR DESCRIPTION
Don't dismiss the token session if the token is from the environment variable.

When logout is called, it means to remove the token from the config file.