### PR TITLE
fix: in terminal show full line for executor usage

### DIFF
--- a/hubble/executor/hubio.py
+++ b/hubble/executor/hubio.py
@@ -718,11 +718,11 @@ metas:
         ) + (f'/{tag}' if tag else '')
 
         if not self.args.no_usage:
-            self._get_prettyprint_usage(console, usage)
+            self._prettyprint_usage(console, usage)
 
         return uuid8, secret
 
-    def _get_prettyprint_usage(self, console, executor_name, usage_kind=None):
+    def _prettyprint_usage(self, console, executor_name):
         from rich import box
         from rich.panel import Panel
         from rich.syntax import Syntax
@@ -730,29 +730,50 @@ metas:
 
         param_str = Table(
             box=box.SIMPLE,
+            show_header=False,
         )
         param_str.add_column('')
-        param_str.add_column('YAML')
-        param_str.add_column('Python')
+        param_str.add_column('')
+        param_str.add_column('')
+
         param_str.add_row(
             'Container',
+            'YAML',
             Syntax(f"uses: jinahub+docker://{executor_name}", 'yaml'),
+        )
+        param_str.add_row(
+            None,
+            'Python',
             Syntax(f".add(uses='jinahub+docker://{executor_name}')", 'python'),
         )
 
+        param_str.add_row()
         param_str.add_row(
             'Sandbox',
+            'YAML',
             Syntax(f"uses: jinahub+sandbox://{executor_name}", 'yaml'),
+        )
+        param_str.add_row(
+            '',
+            'Python',
             Syntax(f".add(uses='jinahub+sandbox://{executor_name}')", 'python'),
         )
 
+        param_str.add_row()
         param_str.add_row(
             'Source',
+            'YAML',
             Syntax(f"uses: jinahub://{executor_name}", 'yaml'),
+        )
+        param_str.add_row(
+            '',
+            'Python',
             Syntax(f".add(uses='jinahub://{executor_name}')", 'python'),
         )
 
-        console.print(Panel(param_str, title='Usage', expand=False, width=100))
+        console.print(
+            Panel(param_str, title='Usage', expand=False, width=len(executor_name) + 65)
+        )
 
     def _prettyprint_build_env_usage(self, console, build_env, usage_kind=None):
         from rich import box
@@ -1170,7 +1191,6 @@ metas:
         console = get_rich_console()
         cached_zip_file = None
         executor_name = None
-        usage_kind = None
         build_env = None
 
         try:
@@ -1216,7 +1236,6 @@ metas:
                             log_stream,
                             console,
                         )
-                    usage_kind = 'docker'
                     return f'docker://{executor.image_name}'
                 elif scheme == 'jinahub':
                     import filelock
@@ -1278,7 +1297,6 @@ metas:
 
                             pkg_path, _ = get_dist_path_of_executor(executor)
 
-                        usage_kind = 'source'
                         return f'{pkg_path / "config.yml"}'
                 else:
                     raise ValueError(f'{self.args.uri} is not a valid scheme')
@@ -1293,4 +1311,4 @@ metas:
                 cached_zip_file.unlink()
 
             if not self.args.no_usage and executor_name:
-                self._get_prettyprint_usage(console, executor_name, usage_kind)
+                self._prettyprint_usage(console, executor_name)

--- a/tests/unit/executor/test_hubio.py
+++ b/tests/unit/executor/test_hubio.py
@@ -1007,13 +1007,12 @@ def test_pull(mocker, monkeypatch, executor_name, build_env):
     monkeypatch.setattr(requests, 'get', _mock_download)
     monkeypatch.setattr(requests, 'head', _mock_head)
 
-    def _mock_get_prettyprint_usage(self, console, executor_name, usage_kind=None):
+    def _mock_prettyprint_usage(self, console, executor_name):
         mock(console=console)
-        mock(usage_kind=usage_kind)
-        print('_mock_get_prettyprint_usage executor_name:', executor_name)
+        print('_mock_prettyprint_usage executor_name:', executor_name)
         assert executor_name != 'None'
 
-    monkeypatch.setattr(HubIO, '_get_prettyprint_usage', _mock_get_prettyprint_usage)
+    monkeypatch.setattr(HubIO, '_prettyprint_usage', _mock_prettyprint_usage)
 
     monkeypatch.setenv('DOWNLOAD', 'download')
     monkeypatch.setenv('DOMAIN', 'github.com')


### PR DESCRIPTION
Fixes https://github.com/jina-ai/hubble/issues/605

## current
![Screenshot 2022-10-06 at 12 04 12](https://user-images.githubusercontent.com/492616/194285716-68ca9dc7-f507-4306-b3a2-60db67c305b4.png)

## new
![Screenshot 2022-10-06 at 11 59 24](https://user-images.githubusercontent.com/492616/194285844-ae36217a-1509-443d-b11b-81a09f3bb656.png)

Now, width is dynamic.. Depending on the length of the line, it will grow.
![Screenshot 2022-10-06 at 11 59 06](https://user-images.githubusercontent.com/492616/194286251-c92cbccd-ea2d-44a9-acce-8d6f6da7c455.png)

Will show `...` if it doesn't fit into the terminal width.
![Screenshot 2022-10-06 at 12 09 19](https://user-images.githubusercontent.com/492616/194286859-4291bd2d-bdff-42cd-944e-7fae37638969.png)
