### PR TITLE
fix: fix the cache path to ~/.cache/jina

### DIFF
--- a/hubble/executor/helper.py
+++ b/hubble/executor/helper.py
@@ -38,7 +38,7 @@ __resources_path__ = os.path.join(
 
 __unset_msg__ = '(unset)'
 
-__cache_path__ = f'{os.path.expanduser("~")}/.cache/{__package__}'
+__cache_path__ = f'{os.path.expanduser("~")}/.cache/jina'
 if not Path(__cache_path__).exists():
     Path(__cache_path__).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
the cache path from  ~/.cache/hubble.executor/  to  ~/.cache/jina