### PR TITLE
feat: add post success callable to login success callback

### DIFF
--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -1,7 +1,7 @@
 import json
 import os
 import webbrowser
-from typing import Optional
+from typing import Callable, Optional
 from urllib.parse import urlencode, urljoin
 
 import aiohttp
@@ -176,7 +176,9 @@ class Auth:
             raise AuthenticationFailedError("Could not validate token")
 
     @staticmethod
-    def login_notebook(force=False, onclick_callback=None, **kwargs):
+    def login_notebook(
+        force: bool = False, post_success: Optional[Callable] = None, **kwargs
+    ):
         """Login user in notebook environments like colab"""
 
         # trying to import utilities (only available in notebook env)
@@ -263,6 +265,8 @@ The function also requires `ipywidgets`.
         def _success_callback(**kwargs):
             clear_output()
             display(success_widget)
+            if post_success:
+                post_success()
 
         def _redirect_callback(href=None, **kwargs):
             redirect_url_widget.value = NOTEBOOK_REDIRECT_HTML.format(
@@ -307,8 +311,8 @@ The function also requires `ipywidgets`.
                 **kwargs,
             )
 
-        token_button_widget.on_click(_login, callback=onclick_callback)
-        browser_button_widget.on_click(_login, callback=onclick_callback)
+        token_button_widget.on_click(_login)
+        browser_button_widget.on_click(_login)
 
         # verifying existing token
         token = Auth.get_auth_token()

--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -176,7 +176,7 @@ class Auth:
             raise AuthenticationFailedError("Could not validate token")
 
     @staticmethod
-    def login_notebook(force=False, **kwargs):
+    def login_notebook(force=False, onclick_callback=None, **kwargs):
         """Login user in notebook environments like colab"""
 
         # trying to import utilities (only available in notebook env)
@@ -307,8 +307,8 @@ The function also requires `ipywidgets`.
                 **kwargs,
             )
 
-        token_button_widget.on_click(_login)
-        browser_button_widget.on_click(_login)
+        token_button_widget.on_click(_login, callback=onclick_callback)
+        browser_button_widget.on_click(_login, callback=onclick_callback)
 
         # verifying existing token
         token = Auth.get_auth_token()


### PR DESCRIPTION
This `post_success` callable event should enable Finetuner client execute some custom function after hubble login succeed.  Since `notebook_login` is non-blocking, we'll have an issue to perform follow-up activities.

see [here](https://github.com/jina-ai/finetuner/pull/576/files#diff-7de38a8a66d22913731b9375e96563a19e4deef2dbcc2c7bde98f4ed49e72072R38)

See it lively:

![C3FC0C22-6094-4047-84B2-7462AAEBD725](https://user-images.githubusercontent.com/9794489/196136389-52738518-8dc0-4583-86d0-c28e8fbb4977.png)
