### PR TITLE
fix: response json decode error

### DIFF
--- a/hubble/api.py
+++ b/hubble/api.py
@@ -4,6 +4,7 @@ from . import Client
 from . import login as _login
 from . import logout as _logout
 from .excepts import AuthenticationFailedError, AuthenticationRequiredError
+from .utils.api_utils import get_json_from_response
 
 
 def logout(*args):
@@ -53,7 +54,8 @@ def token(args):
         )
 
         response.raise_for_status()
-        token = response.json()['data']['token']
+        json_response = get_json_from_response(response)
+        token = json_response['data']['token']
 
         import rich
         from rich.panel import Panel
@@ -88,7 +90,8 @@ You can set it as an env var [b]JINA_AUTH_TOKEN[/b]''',
     if args.operation == 'list':
         response = client.list_personal_access_tokens()
         response.raise_for_status()
-        tokens = response.json()['data']['personal_access_tokens']
+        json_response = get_json_from_response(response)
+        tokens = json_response['data']['personal_access_tokens']
 
         import rich
         from rich.table import Table

--- a/hubble/client/base.py
+++ b/hubble/client/base.py
@@ -38,7 +38,13 @@ class BaseClient(object):
 
     def _handle_error_request(self, resp: Union[requests.Response, dict]):
         if isinstance(resp, requests.Response):
-            resp = resp.json()
+            try:
+                resp = resp.json()
+            except Exception:
+                resp = {
+                    'message': resp.text,
+                    'code': resp.status_code,
+                }
 
         message = resp.get('message', None)
         code = resp.get('status', -1)

--- a/hubble/client/base.py
+++ b/hubble/client/base.py
@@ -3,7 +3,7 @@ from typing import IO, Any, MutableMapping, Optional, Text, Union
 import requests
 
 from ..excepts import errorcodes
-from ..utils.api_utils import get_base_url
+from ..utils.api_utils import get_base_url, get_json_from_response
 from ..utils.auth import Auth
 from .session import HubbleAPISession
 
@@ -38,13 +38,7 @@ class BaseClient(object):
 
     def _handle_error_request(self, resp: Union[requests.Response, dict]):
         if isinstance(resp, requests.Response):
-            try:
-                resp = resp.json()
-            except Exception:
-                resp = {
-                    'message': resp.text,
-                    'code': resp.status_code,
-                }
+            resp = get_json_from_response(resp)
 
         message = resp.get('message', None)
         code = resp.get('status', -1)
@@ -88,6 +82,6 @@ class BaseClient(object):
             self._handle_error_request(resp)
 
         if self._jsonify:
-            return resp.json()
+            resp = get_json_from_response(resp)
 
         return resp

--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Union
 
 import requests
 
+from ..utils.api_utils import get_json_from_response
 from .base import BaseClient
 from .endpoints import EndpointsV2
 
@@ -170,7 +171,7 @@ class Client(BaseClient):
 
         # Second download artifact.
         if isinstance(resp, requests.Response):
-            resp = resp.json()
+            resp = get_json_from_response(resp)
         download_url = resp['data']['download']
 
         pbar = get_progressbar(disable=not show_progress)

--- a/hubble/executor/hubio.py
+++ b/hubble/executor/hubio.py
@@ -43,6 +43,7 @@ from hubble.executor.hubapi import (
     load_config,
     load_secret,
 )
+from hubble.utils.api_utils import get_json_from_response
 
 
 class HubIO:
@@ -1086,7 +1087,7 @@ metas:
         req_header = get_request_header()
 
         resp = _send_request_with_retry(pull_url, json=payload, headers=req_header)
-        resp = resp.json()['data']
+        resp = get_json_from_response(resp)['data']
 
         images = resp['package'].get('containers', [])
         image_name = images[0] if images else None
@@ -1144,11 +1145,12 @@ metas:
         port = None
 
         headers = get_request_header()
-        json_response = requests.post(
+        response = requests.post(
             url=urljoin(hubble.utils.get_base_url(), 'sandbox.get'),
             json=payload,
             headers=headers,
-        ).json()
+        )
+        json_response = get_json_from_response(response)
         if json_response.get('code') == 200:
             host = json_response.get('data', {}).get('host', None)
             port = json_response.get('data', {}).get('port', None)
@@ -1161,11 +1163,12 @@ metas:
             f'[bold green]🚧 Deploying sandbox for [bold white]{name}[/bold white] since none exists...'
         ):
             try:
-                json_response = requests.post(
+                response = requests.post(
                     url=urljoin(hubble.utils.get_base_url(), 'sandbox.create'),
                     json=payload,
                     headers=headers,
-                ).json()
+                )
+                json_response = get_json_from_response(response)
 
                 data = json_response.get('data') or {}
                 host = data.get('host', None)

--- a/hubble/utils/api_utils.py
+++ b/hubble/utils/api_utils.py
@@ -28,5 +28,7 @@ def get_json_from_response(resp: Response) -> dict:
         return resp.json()
     except JSONDecodeError as err:
         raise JSONDecodeError(
-            f'{err.msg}; Response: {resp.text}, status code: {resp.status_code}'
+            f'Response: {resp.text}, status code: {resp.status_code}; {err.msg}',
+            err.doc,
+            err.pos,
         ) from err

--- a/hubble/utils/api_utils.py
+++ b/hubble/utils/api_utils.py
@@ -1,4 +1,7 @@
 import os
+from json import JSONDecodeError
+
+from requests import Response
 
 DOMAIN = 'https://api.hubble.jina.ai'
 PROTOCOL = 'rpc'
@@ -13,3 +16,17 @@ def get_base_url():
         domain = os.environ['JINA_HUBBLE_REGISTRY']
 
     return f'{domain}/{VERSION}/{PROTOCOL}/'
+
+
+def get_json_from_response(resp: Response) -> dict:
+    """
+    Get the JSON data from the response.
+    If the response isn't JSON, the response information is lost.
+    The error message must include the response body and status code.
+    """
+    try:
+        return resp.json()
+    except JSONDecodeError as err:
+        raise JSONDecodeError(
+            f'{err.msg}; Response: {resp.text}, status code: {resp.status_code}'
+        ) from err

--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -8,7 +8,7 @@ import aiohttp
 import requests
 from hubble.client.session import HubbleAPISession
 from hubble.excepts import AuthenticationFailedError
-from hubble.utils.api_utils import get_base_url
+from hubble.utils.api_utils import get_base_url, get_json_from_response
 from hubble.utils.config import config
 from rich import print as rich_print
 
@@ -404,7 +404,7 @@ The function also requires `ipywidgets`.
         url = urljoin(api_host, 'user.identity.grant.auto')
         response = requests.post(url, json=auth_info)
         response.raise_for_status()
-        json_response = response.json()
+        json_response = get_json_from_response(response)
         token = json_response['data']['token']
         config.set('auth_token', token)
 

--- a/tests/unit/utils/test_api_utils.py
+++ b/tests/unit/utils/test_api_utils.py
@@ -1,0 +1,16 @@
+from json import JSONDecodeError
+
+import pytest
+from hubble.utils.api_utils import get_json_from_response
+from requests import Response
+
+
+def test_get_json_from_response():
+    resp = Response()
+    resp.status_code = 502
+    resp._content = b'Bad Gateway'
+
+    with pytest.raises(JSONDecodeError) as exc_info:
+        get_json_from_response(resp)
+
+    assert 'Response: Bad Gateway, status code: 502;' in str(exc_info.value)


### PR DESCRIPTION
When a response body is not JSON, we can't parse it. Therefore, we cannot see any response details.

It makes debugging almost impossible when something is wrong.

- [x] add tests
- [x] check every place that calls `resp.json()` and catch decode (any) error.

```
2022-10-20T11:09:59.795Z
resp = client.upload_artifact(
2022-10-20T11:09:59.795Z
File "/usr/local/lib/python3.8/site-packages/hubble/client/client.py", line 146, in upload_artifact
2022-10-20T11:09:59.795Z
return self.handle_request(
2022-10-20T11:09:59.795Z
File "/usr/local/lib/python3.8/site-packages/hubble/client/base.py", line 82, in handle_request
2022-10-20T11:09:59.795Z
self._handle_error_request(resp)
2022-10-20T11:09:59.795Z
File "/usr/local/lib/python3.8/site-packages/hubble/client/base.py", line 41, in _handle_error_request
2022-10-20T11:09:59.795Z
resp = resp.json()
2022-10-20T11:09:59.795Z
File "/usr/local/lib/python3.8/site-packages/requests/models.py", line 975, in json
2022-10-20T11:09:59.795Z
raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
2022-10-20T11:09:59.795Z
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Ref: https://jinaai.slack.com/archives/C023A7RAPGR/p1666266667585769