### PR TITLE
fix: change issue URLs to point to hubble-sdk

### DIFF
--- a/hubble/executor/helper.py
+++ b/hubble/executor/helper.py
@@ -437,7 +437,7 @@ def download_with_resume(
             'MD5 checksum failed.'
             'Might happen when the network is unstable, please retry.'
             'If still not work, feel free to raise an issue.'
-            'https://github.com/jina-ai/jina/issues/new'
+            'https://github.com/jina-ai/jina-hubble-sdk/issues/new'
         )
 
     return filepath

--- a/hubble/executor/hubio.py
+++ b/hubble/executor/hubio.py
@@ -661,7 +661,7 @@ metas:
             except Exception as e:  # IO related errors
                 self.logger.error(
                     f'Please report this session_id: [yellow bold]{req_header["jinameta-session-id"]}[/] '
-                    'to https://github.com/jina-ai/jina/issues'
+                    'to https://github.com/jina-ai/jina-hubble-sdk/issues'
                 )
                 raise e
 
@@ -1179,7 +1179,7 @@ metas:
                 console.log('🎉 Deployment completed, using it.')
             except BaseException:
                 console.log(
-                    '🚨 Deployment failed. Please raise an issue: https://github.com/jina-ai/jina/issues/new'
+                    '🚨 Deployment failed. Please raise an issue: https://github.com/jina-ai/jina-hubble-sdk/issues/new'
                 )
                 raise
 


### PR DESCRIPTION
Issues with the hubble sdk such as `jina hub push` should be reported in jina-hubble-sdk instead of the jina repository

Fixes #91 