### PR TITLE
fix: use async login when not in notebook environment

### DIFF
--- a/hubble/__init__.py
+++ b/hubble/__init__.py
@@ -65,7 +65,7 @@ def login(interactive: Optional[bool] = None, **kwargs):
     if interactive:
         Auth.login_notebook(**kwargs)
     else:
-        Auth.login_sync(**kwargs)
+        Auth.login_async(**kwargs)
 
 
 def notebook_login(**kwargs):


### PR DESCRIPTION
Ref: #101 