### PR TITLE
fix: update interactive login success message

### DIFF
--- a/hubble/utils/auth.py
+++ b/hubble/utils/auth.py
@@ -80,7 +80,7 @@ NOTEBOOK_SUCCESS_HTML = f"""
             You are logged in to Jina AI!
         </p>
         <p>
-            If you want to log in again, run <code>notebook_login(force=True)</code>.
+            To log in again, run <code>login(force=True)</code>.
         </p>
     </center>
 </div>


### PR DESCRIPTION
Ref #121 

This PR updates the interactive login success message.

<img width="334" alt="Screen Shot 2022-11-22 at 13 21 18" src="https://user-images.githubusercontent.com/15995496/203230610-59a94fef-339d-4e02-a12c-725898d9d2ab.png">
