### PR TITLE
chore: add ci check for jina ecosystem packages compatibility

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -1,0 +1,37 @@
+name: Nightly Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: main
+  schedule:
+    - cron: "0 6 * * 1-5"   # runs at 6AM UTC (mon-fri)
+  # pull_request:             # uncomment this if you want to run nightly tests in your PR
+
+jobs:
+  install-jina-ecosystem-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Prepare environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          JINA_VERSION=$(curl -L -s "https://pypi.org/pypi/jina/json" |  jq  -r '.releases | keys | .[]| select(startswith("3."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina==$JINA_VERSION
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+      - name: Test import all
+        run: |
+          python -c 'from jina import *'
+          python -c 'from hubble import *'
+          python -c 'from docarray import *'

--- a/.github/workflows/style-and-test-check.yml
+++ b/.github/workflows/style-and-test-check.yml
@@ -24,4 +24,30 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage.xml
-        
+
+  install-jina-ecosystem-test:
+    runs-on: ubuntu-latest
+    needs: [style-lint-test]
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Prepare environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install wheel
+          JINA_VERSION=$(curl -L -s "https://pypi.org/pypi/jina/json" |  jq  -r '.releases | keys | .[]| select(startswith("3."))'  | sort -V | tail -1)
+          DOCARRAY_VERSION=$(curl -L -s "https://pypi.org/pypi/docarray/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          JCLOUD_VERSION=$(curl -L -s "https://pypi.org/pypi/jcloud/json" |  jq  -r '.releases | keys | .[]| select(startswith("0."))'  | sort -V | tail -1)
+          pip install . jcloud==$JCLOUD_VERSION docarray==$DOCARRAY_VERSION jina==$JINA_VERSION
+      - name: Test basic import
+        run: python -c 'from jina import Executor,requests'
+      - name: Test import all
+        run: |
+          python -c 'from jina import *'
+          python -c 'from hubble import *'
+          python -c 'from docarray import *'


### PR DESCRIPTION
Closes #135 

Installs the latest versions of `jina`, `docarray` and `jcloud` with current `hubble-sdk`. Then tries to import those.