### PR TITLE
feat: allow upload artifact with name

### DIFF
--- a/hubble/client/client.py
+++ b/hubble/client/client.py
@@ -81,6 +81,7 @@ class Client(BaseClient):
         self,
         f: Union[str, io.BytesIO],
         id: Optional[str] = None,
+        name: Optional[str] = None,
         metadata: Optional[dict] = None,
         is_public: bool = False,
         show_progress: bool = False,
@@ -89,6 +90,7 @@ class Client(BaseClient):
 
         :param f: The full path or the `io.BytesIO` of the file to be uploaded.
         :param id: Optional value, the id of the artifact.
+        :param name: Optional value, the name of the artifact.
         :param metadata: Optional value, the metadata of the artifact.
         :param is_public: Optional value, if this artifact is public or not,
           default not public.
@@ -137,6 +139,8 @@ class Client(BaseClient):
 
         if id:
             dict_data['id'] = id
+        if name:
+            dict_data['name'] = name
         if metadata:
             dict_data['metaData'] = json.dumps(metadata)
 

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -68,7 +68,9 @@ def test_upload_get_delete_artifact(client, tmpdir):
     assert data['visibility'] == 'private'
     assert data.get('metaData', None) is None
 
-    resp = client.update_artifact(id=artifact_id1, is_public=True, metadata={'a': 1})
+    resp = client.update_artifact(
+        id=artifact_id1, is_public=True, metadata={'a': 1}, name='test-da'
+    )
     if not client._jsonify:
         resp = resp.json()
 
@@ -76,6 +78,7 @@ def test_upload_get_delete_artifact(client, tmpdir):
 
     assert data['visibility'] == 'public'
     assert data['metaData'] == {'a': 1}
+    assert data['name'] == 'test-da'
 
     # upload from bytesio
     resp = client.upload_artifact(


### PR DESCRIPTION
This PR should allow user to upload an artifact with a `name`, similar as `DocumentArray.push(name='da-name')`