### PR TITLE
feat: executor push with optional platform param

### DIFF
--- a/hubble/executor/helper.py
+++ b/hubble/executor/helper.py
@@ -626,7 +626,6 @@ def disk_cache_offline(
             import filelock
 
             call_hash = f'{func.__name__}({", ".join(map(str, args))})'
-
             pickle_protocol = 4
             file_lock = nullcontext()
 

--- a/hubble/executor/hubio.py
+++ b/hubble/executor/hubio.py
@@ -471,6 +471,10 @@ metas:
                 build_env_dict[env_list[0]] = env_list[1]
             build_env = build_env_dict if build_env_dict else None
 
+        platform = None
+        if self.args.platform:
+            platform = self.args.platform
+
         requirements_file = work_path / 'requirements.txt'
 
         requirements_env_variables = []
@@ -552,6 +556,9 @@ metas:
 
                 if build_env:
                     form_data['buildEnv'] = json.dumps(build_env)
+
+                if platform:
+                    form_data['platform'] = platform
 
                 st.update('Connecting to Jina Hub ...')
 

--- a/hubble/executor/parsers/pull.py
+++ b/hubble/executor/parsers/pull.py
@@ -21,6 +21,11 @@ def mixin_hub_pull_options_parser(parser):
         default=False,
         help='If set, always pull the latest Hub Executor bundle even it exists on local',
     )
+    gp.add_argument(
+        '--prefer-platform',
+        type=str,
+        help='The preferred target Docker platform. (e.g. "linux/amd64", "linux/arm64")',
+    )
 
 
 def mixin_hub_pull_parser(parser):

--- a/hubble/executor/parsers/push.py
+++ b/hubble/executor/parsers/push.py
@@ -68,6 +68,12 @@ One can later fetch a tagged Executor via `jinaai[+docker]://<username>/MyExecut
         help='A list of environment variables. It will be used in project build phase.',
     )
     gp.add_argument(
+        '--platform',
+        type=str,
+        help='A comma separated list of target Docker platforms. Explicitly set target platform(s) for build. '
+        '(e.g. "linux/amd64,linux/arm64")',
+    )
+    gp.add_argument(
         '--secret',
         type=str,
         help='The secret for overwrite a Hub executor',

--- a/tests/unit/executor/test_hubio.py
+++ b/tests/unit/executor/test_hubio.py
@@ -205,6 +205,7 @@ class StatusPostMockResponse:
 @pytest.mark.parametrize('path', ['dummy_executor'])
 @pytest.mark.parametrize('mode', ['--public', '--private'])
 @pytest.mark.parametrize('build_env', [['DOMAIN=github.com', 'DOWNLOAD=download']])
+@pytest.mark.parametrize('platform', ['linux/amd64', 'linux/amd64,linux/arm64'])
 @pytest.mark.parametrize('verbose', [False, True])
 def test_push(
     mocker,
@@ -216,6 +217,7 @@ def test_push(
     tag,
     no_cache,
     build_env,
+    platform,
     verbose,
 ):
     mock = mocker.Mock()
@@ -245,6 +247,9 @@ def test_push(
     if build_env:
         for env in build_env:
             _args_list.extend(['--build-env', env])
+
+    if platform:
+        _args_list.extend(['--platform', platform])
 
     if verbose:
         _args_list.append('--verbose')

--- a/tests/unit/executor/test_hubio.py
+++ b/tests/unit/executor/test_hubio.py
@@ -714,8 +714,9 @@ def test_fetch(mocker, monkeypatch, rebuild_image, prefer_platform):
     executor, _ = HubIO(args).fetch_meta(
         'dummy_mwu_encoder',
         None,
-        rebuild_image=rebuild_image,
-        prefer_platform=prefer_platform,
+        True,
+        rebuild_image,
+        prefer_platform,
         force=True,
     )
 
@@ -809,7 +810,7 @@ def test_fetch_with_retry(mocker, monkeypatch):
         # failing 3 times, so it should raise an error
         HubIO.fetch_meta('dummy_mwu_encoder', tag=None, force=True)
 
-    assert exc_info.match('{"message": "Internal server error"}')
+    assert exc_info.match('Internal server error')
 
     mock_response = FetchMetaMockResponse(response_code=200, fail_count=2)
 
@@ -866,6 +867,7 @@ def test_pull(mocker, monkeypatch, executor_name, build_env, executor_uri):
         tag=None,
         image_required=True,
         rebuild_image=True,
+        prefer_platform=None,
         *,
         secret=None,
         force=False,

--- a/tests/unit/executor/test_hubio.py
+++ b/tests/unit/executor/test_hubio.py
@@ -945,6 +945,7 @@ def test_offline_pull(mocker, monkeypatch, tmpfile):
         tag,
         image_required=True,
         rebuild_image=True,
+        prefer_platform=None,
         *,
         secret=None,
         force=False,

--- a/tests/unit/executor/test_hubio.py
+++ b/tests/unit/executor/test_hubio.py
@@ -700,7 +700,8 @@ def test_status_with_error(
 
 
 @pytest.mark.parametrize('rebuild_image', [True, False])
-def test_fetch(mocker, monkeypatch, rebuild_image):
+@pytest.mark.parametrize('prefer_platform', ['arm64', 'amd64'])
+def test_fetch(mocker, monkeypatch, rebuild_image, prefer_platform):
     mock = mocker.Mock()
 
     def _mock_post(url, json, headers=None):
@@ -714,6 +715,7 @@ def test_fetch(mocker, monkeypatch, rebuild_image):
         'dummy_mwu_encoder',
         None,
         rebuild_image=rebuild_image,
+        prefer_platform=prefer_platform,
         force=True,
     )
 


### PR DESCRIPTION
This is to support multi-platform build for executors.
Depending on the server implementation the supported platforms are a subset of Docker platforms: https://docs.docker.com/build/building/multi-platform/
As the supported platforms may be changed by the server, this parameter is not checked on the client side.