### PR TITLE
fix: move `--install-requirements` from hub pull options

### DIFF
--- a/hubble/executor/parsers/pull.py
+++ b/hubble/executor/parsers/pull.py
@@ -9,12 +9,6 @@ def mixin_hub_pull_options_parser(parser):
 
     gp = add_arg_group(parser, title='Pull')
     gp.add_argument(
-        '--install-requirements',
-        action='store_true',
-        default=False,
-        help='If set, install `requirements.txt` in the Hub Executor bundle to local',
-    ),
-    gp.add_argument(
         '--force-update',
         '--force',
         action='store_true',
@@ -26,6 +20,8 @@ def mixin_hub_pull_options_parser(parser):
         type=str,
         help='The preferred target Docker platform. (e.g. "linux/amd64", "linux/arm64")',
     )
+
+    return gp
 
 
 def mixin_hub_pull_parser(parser):
@@ -44,4 +40,10 @@ def mixin_hub_pull_parser(parser):
         type=hub_uri,
         help='The URI of the executor to pull (e.g., jinaai[+docker]://<username>/NAME)',
     )
-    mixin_hub_pull_options_parser(parser)
+    pull_group = mixin_hub_pull_options_parser(parser)
+    pull_group.add_argument(
+        '--install-requirements',
+        action='store_true',
+        default=False,
+        help='If set, install `requirements.txt` in the Hub Executor bundle to local',
+    ),


### PR DESCRIPTION
Jina pod is having its own version of mixin_hub_pull_options_parser. This aims to let them import from hubble