### PR TITLE
feat: allow raw display of hub token

### DIFF
--- a/hubble/api.py
+++ b/hubble/api.py
@@ -65,7 +65,7 @@ def token(args):
             rich.print(
                 Panel(
                     f'''[b]{token}[/b]
-    
+
     You can set it as an env var [b]JINA_AUTH_TOKEN[/b]''',
                     title=':party_popper: [green]New token created[/]',
                     subtitle=':point_up:️ [yellow] This token is only shown once![/]',

--- a/hubble/api.py
+++ b/hubble/api.py
@@ -56,20 +56,22 @@ def token(args):
         response.raise_for_status()
         json_response = get_json_from_response(response)
         token = json_response['data']['token']
+        if args.format == 'raw':
+            print(token)
+        elif args.format == 'table':
+            import rich
+            from rich.panel import Panel
 
-        import rich
-        from rich.panel import Panel
-
-        rich.print(
-            Panel(
-                f'''[b]{token}[/b]
-
-You can set it as an env var [b]JINA_AUTH_TOKEN[/b]''',
-                title=':party_popper: [green]New token created[/]',
-                subtitle=':point_up:️ [yellow] This token is only shown once![/]',
-                width=50,
+            rich.print(
+                Panel(
+                    f'''[b]{token}[/b]
+    
+    You can set it as an env var [b]JINA_AUTH_TOKEN[/b]''',
+                    title=':party_popper: [green]New token created[/]',
+                    subtitle=':point_up:️ [yellow] This token is only shown once![/]',
+                    width=50,
+                )
             )
-        )
 
     if args.operation == 'delete':
         response = client.delete_personal_access_token(name=args.name)

--- a/hubble/parsers/token.py
+++ b/hubble/parsers/token.py
@@ -27,6 +27,13 @@ def set_token_parser(parent_parser: 'ArgumentParser' = None):
     )
 
     create_parser.add_argument(
+        '--format',
+        type=str,
+        default='table',
+        help='Display format of the token, one of [table, raw]',
+    )
+
+    create_parser.add_argument(
         'name',
         type=str,
         help='Name of Personal Access Token',


### PR DESCRIPTION
feat: allow raw display of hub token

usage: jina auth token  create my-token --format raw

This will allow using jina auth token create cli from the shell and parsing results